### PR TITLE
register callbacks from create() options

### DIFF
--- a/statemachine.lua
+++ b/statemachine.lua
@@ -61,6 +61,10 @@ function machine.create(options)
     add_to_map(fsm.events[name].map, event)
   end
 
+  for name, callback in pairs(options.callbacks) do
+    fsm[name] = callback
+  end
+
   return fsm
 end
 


### PR DESCRIPTION
I added a loop to register the callbacks from the create method, so callbacks can be fired, according to what the documentation says.
