### PR TITLE
Update the unit tests so they quit failing.

### DIFF
--- a/spec/fsm_spec.lua
+++ b/spec/fsm_spec.lua
@@ -68,11 +68,15 @@ describe("Lua state machine framework", function()
 
       fsm:warn()
 
+      fsm.current = 'green'
       assert.spy(fsm.onbeforewarn).was_called_with(fsm, 'warn', 'green', 'yellow')
       assert.spy(fsm.onleavegreen).was_called_with(fsm, 'warn', 'green', 'yellow')
+
+      fsm.current = 'yellow'
       assert.spy(fsm.onenteryellow).was_called_with(fsm, 'warn', 'green', 'yellow')
       assert.spy(fsm.onafterwarn).was_called_with(fsm, 'warn', 'green', 'yellow')
       assert.spy(fsm.onstatechange).was_called_with(fsm, 'warn', 'green', 'yellow')
+
       assert.spy(fsm.onyellow).was_not_called()
       assert.spy(fsm.onwarn).was_not_called()
     end)
@@ -89,8 +93,11 @@ describe("Lua state machine framework", function()
 
       fsm:warn()
 
+      fsm.current = 'green'
       assert.spy(fsm.onbeforewarn).was_called_with(fsm, 'warn', 'green', 'yellow')
       assert.spy(fsm.onleavegreen).was_called_with(fsm, 'warn', 'green', 'yellow')
+
+      fsm.current = 'yellow'
       assert.spy(fsm.onenteryellow).was_called_with(fsm, 'warn', 'green', 'yellow')
       assert.spy(fsm.onafterwarn).was_called_with(fsm, 'warn', 'green', 'yellow')
       assert.spy(fsm.onstatechange).was_called_with(fsm, 'warn', 'green', 'yellow')
@@ -108,8 +115,11 @@ describe("Lua state machine framework", function()
 
       fsm:warn('bar')
 
+      fsm.current = 'green'
       assert.spy(fsm.onbeforewarn).was_called_with(fsm, 'warn', 'green', 'yellow', 'bar')
       assert.spy(fsm.onleavegreen).was_called_with(fsm, 'warn', 'green', 'yellow', 'bar')
+      
+      fsm.current = 'yellow'
       assert.spy(fsm.onenteryellow).was_called_with(fsm, 'warn', 'green', 'yellow', 'bar')
       assert.spy(fsm.onafterwarn).was_called_with(fsm, 'warn', 'green', 'yellow', 'bar')
       assert.spy(fsm.onstatechange).was_called_with(fsm, 'warn', 'green', 'yellow', 'bar')


### PR DESCRIPTION
Looks like a recent change in busted changed the way comparisons are made in spies. Reverting the state of the FSM to when the callbacks were called seemed to fix the issue with the tests.